### PR TITLE
feat: 데이터베이스 초기 구성 시 심부름 카테고리(청소, 알바, 벌레잡기등) 자동 추가 기능 구현 #228

### DIFF
--- a/backend/src/main/java/ssap/ssap/config/LoadDatabase.java
+++ b/backend/src/main/java/ssap/ssap/config/LoadDatabase.java
@@ -1,0 +1,24 @@
+package ssap.ssap.config;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import ssap.ssap.domain.Category;
+import ssap.ssap.repository.CategoryRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class LoadDatabase {
+    @Bean
+    CommandLineRunner initDatabase(CategoryRepository repository) {
+        return args -> {
+            List<String> categories = Arrays.asList("배달·퀵", "청소", "운반·수리", "동행·육아", "펫", "역할대행", "알바", "벌레잡기", "기타");
+            categories.forEach(name ->
+                    repository.findByCategoryName(name)
+                            .orElseGet(() -> repository.save(new Category(name))));
+        };
+    }
+}
+


### PR DESCRIPTION
## 요약
- 초기 데이터베이스 세팅을 위한 기본 카테고리 추가 기능 구현

## 변경 내용 
- 기본 카테고리 항목("배달·퀵", "청소", "운반·수리", "동행·육아", "펫", "역할대행", "알바", "벌레잡기", "기타") DB에 추가 기능 구현

## 이슈 번호 또는 링크
#228