### PR TITLE
chore: 프록시 설정 관련 코드 주석 처리 #230

### DIFF
--- a/backend/src/main/java/ssap/ssap/config/ProxyConfig.java
+++ b/backend/src/main/java/ssap/ssap/config/ProxyConfig.java
@@ -10,11 +10,11 @@ import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ProxyConfig {
-    @Value("${PROXY_HOST:defaultProxyHost}")
-    private String proxyHost;
+//    @Value("${PROXY_HOST:defaultProxyHost}")
+//    private String proxyHost;
 
-    @Value("${PROXY_PORT:8080}")
-    private int proxyPort;
+//    @Value("${PROXY_PORT:8080}")
+//    private int proxyPort;
 
     @Bean
     public RestTemplate restTemplate() {
@@ -22,10 +22,10 @@ public class ProxyConfig {
         var clientBuilder = HttpClients.custom();
 
         // 프록시 호스트가 설정되어 있다면 프록시를 적용합니다.
-        if (!proxyHost.isEmpty()) {
-            HttpHost proxy = new HttpHost(proxyHost, proxyPort);
-            clientBuilder.setProxy(proxy);
-        }
+//        if (!proxyHost.isEmpty()) {
+//            HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+//            clientBuilder.setProxy(proxy);
+//        }
 
         // HttpClient 인스턴스 생성
         var httpClient = clientBuilder.build();


### PR DESCRIPTION
## 요약
- 카카오 DKOS에서 외부 API 호출 시 사용했던 Proxy 설정 코드가 현재는 불필요하므로 주석 처리

## 변경 내용 
- proxy 설정 코드 주석 처리

## 이슈 번호 또는 링크
#230