### PR TITLE
feat: 유저 주소 정보 저장 API 구현 #237

### DIFF
--- a/backend/src/main/java/ssap/ssap/controller/UserAddressController.java
+++ b/backend/src/main/java/ssap/ssap/controller/UserAddressController.java
@@ -1,0 +1,56 @@
+package ssap.ssap.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import ssap.ssap.dto.UserAddressDTO;
+import ssap.ssap.service.OAuthService;
+import ssap.ssap.service.UserService;
+
+@Slf4j
+@CrossOrigin(origins = "*")
+@Tag(name = "사용자 주소 API", description = "사용자의 주소 정보 관련 API")
+@RestController
+@RequestMapping("/api/user-address")
+public class UserAddressController {
+
+    private final UserService userService;
+    private final OAuthService oAuthService;
+
+    @Autowired
+    public UserAddressController(UserService userService, OAuthService oAuthService) {
+        this.userService = userService;
+        this.oAuthService = oAuthService;
+    }
+
+    @Operation(summary = "사용자 주소 정보 업데이트", description = "사용자의 이메일과 새로운 주소 정보를 사용하여 사용자의 주소를 업데이트합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 주소 업데이트 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserAddressDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청/유효하지 않은 입력"),
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PutMapping
+    public ResponseEntity<?> updateUserAddress(@Valid @RequestBody UserAddressDTO userAddressDTO,
+                                                            @RequestHeader("Authorization") String authorizationHeader) {
+
+        String accessToken = authorizationHeader.substring("Bearer ".length());
+        boolean isValid = oAuthService.isAccessTokenValid(accessToken);
+        if (!isValid) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("액세스 토큰이 유효하지 않거나 만료되었습니다.");
+        }
+
+        UserAddressDTO updatedUserAddressDTO = userService.updateUserAddress(userAddressDTO.getEmail(), userAddressDTO.getAddress());
+        return ResponseEntity.ok(updatedUserAddressDTO);
+
+    }
+}

--- a/backend/src/main/java/ssap/ssap/domain/User.java
+++ b/backend/src/main/java/ssap/ssap/domain/User.java
@@ -34,4 +34,7 @@ public class User {
     @Column(name = "profileImageUrl", nullable = true)
     private String profileImageUrl;
 
+    @Column(name = "address", nullable = true)
+    private String address;
+
 }

--- a/backend/src/main/java/ssap/ssap/dto/UserAddressDTO.java
+++ b/backend/src/main/java/ssap/ssap/dto/UserAddressDTO.java
@@ -1,0 +1,15 @@
+package ssap.ssap.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserAddressDTO {
+    @Email(message = "유효하지 않는 이메일 형식입니다.")
+    private String email;
+    @NotBlank(message = "주소는 비어 있을 수 없습니다.")
+    private String address;
+}

--- a/backend/src/main/java/ssap/ssap/exception/UserNotFoundException.java
+++ b/backend/src/main/java/ssap/ssap/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package ssap.ssap.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/ssap/ssap/service/UserService.java
+++ b/backend/src/main/java/ssap/ssap/service/UserService.java
@@ -1,12 +1,15 @@
 package ssap.ssap.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import ssap.ssap.domain.User;
 import ssap.ssap.dto.Account;
+import ssap.ssap.dto.UserAddressDTO;
 import ssap.ssap.exception.CustomServiceException;
+import ssap.ssap.exception.UserNotFoundException;
 import ssap.ssap.repository.UserRepository;
 
 import java.util.Optional;
@@ -53,5 +56,35 @@ public class UserService {
             log.error("데이터베이스 접근 중 오류 발생: {}", email, e);
             throw new CustomServiceException("데이터베이스 접근 중 오류 발생", e);
         }
+    }
+    public UserAddressDTO updateUserAddress(String email, String address) {
+        if (email == null || email.isBlank() || !EmailValidator.getInstance().isValid(email)) {
+            log.warn("유효하지 않은 이메일 형식: {}", email);
+            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다.");
+        }
+
+        if (email == null || email.isBlank()) {
+            log.debug("이메일이 null이거나 공백입니다: {}", email);
+            throw new IllegalArgumentException("이메일은 비어 있을 수 없습니다.");
+        }
+
+        if (!EmailValidator.getInstance().isValid(email)) {
+            log.info("유효하지 않은 이메일 형식: {}", email);
+            throw new IllegalArgumentException("유효하지 않은 이메일 형식입니다: " + email);
+        }
+
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없음: " + email));
+
+        user.setAddress(address);
+        User savedUser = userRepository.save(user);
+        log.info("사용자 주소 정보 업데이트: {}", email);
+
+        UserAddressDTO userAddressDTO = new UserAddressDTO();
+        userAddressDTO.setEmail(savedUser.getEmail());
+        userAddressDTO.setAddress(savedUser.getAddress());
+
+        return userAddressDTO;
     }
 }


### PR DESCRIPTION
## 요약
- 유저 주소 정보 저장 API 구현

## 변경 내용 
- 사용자 주소 정보를 저장(업데이트)하는 API 구현
- UserAddressDTO를 통해 이메일과 주소 필드의 유효성 검증 로직 적용
- UserAddressController에 액세스 토큰 유효성 검증 로직 추가
- GlobalExceptionHandler에 새로운 예외 처리 로직 추가하여, API 예외 상황에 대응하도록 처리

## 이슈 번호 또는 링크
#237